### PR TITLE
Async Tests & Add bandwidth usage metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/cover.out
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Usage of ./speedtest-exporter:
         enables process stats exporter
   -saving-mode
         enables saving mode in speedtest-go to reduce bandwidth usage at the cost of accuracy
+  -test-interval duration
+        interval between speedtest runs (default 1h0m0s)
   -test-timeout duration
-        timeout for speedtest runs (default 10s)
+        timeout for speedtest runs (default 1m0s)
 ```
 
 ## Running via Docker
@@ -74,6 +76,12 @@ kubectl apply -n <your namespace> -f kubernetes/manifests/
 NOTE: dummy data in this output to prevent leakage
 
 ```prometheus
+# HELP speedtest_bytes_downloaded Total bytes downloaded
+# TYPE speedtest_bytes_downloaded counter
+speedtest_bytes_downloaded 3.9929023e+08
+# HELP speedtest_bytes_uploaded Total bytes uploaded
+# TYPE speedtest_bytes_uploaded counter
+speedtest_bytes_uploaded 1.61978916e+08
 # HELP speedtest_download_speed_mbps Latency to Speedtest Server in seconds
 # TYPE speedtest_download_speed_mbps gauge
 speedtest_download_speed_mbps{country="United States",distance="1.0",lat="1.0",lon="-1.0",name="Anytown, USA",server_id="1",sponsor="Dat Sponsor Doh",url="http://speedtest.example.net:8080/speedtest/upload.php"} 716.7810615213976
@@ -89,6 +97,9 @@ speedtest_target_update_duration_ms 0.206249213
 # HELP speedtest_test_duration_ms Duration of speedtest runs in seconds
 # TYPE speedtest_test_duration_ms gauge
 speedtest_test_duration_ms 6.257747472
+# HELP speedtest_unknown_content_size Total number of times the content size was unknown
+# TYPE speedtest_unknown_content_size counter
+speedtest_unknown_content_size 2
 # HELP speedtest_upload_speed_mbps Latency to Speedtest Server in seconds
 # TYPE speedtest_upload_speed_mbps gauge
 speedtest_upload_speed_mbps{country="United States",distance="1.0",lat="1.0",lon="-1.0",name="Anytown, USA",server_id="1",sponsor="Dat Sponsor Doh",url="http://speedtest.example.net:8080/speedtest/upload.php"} 724.4910836862521

--- a/internal/bandwidth_observer/bandwidth_observer.go
+++ b/internal/bandwidth_observer/bandwidth_observer.go
@@ -1,0 +1,79 @@
+package bandwidth_observer
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog/log"
+)
+
+type BandwidthObserver struct {
+	T                  http.RoundTripper
+	bytesUploaded      prometheus.Counter
+	bytesDownloaded    prometheus.Counter
+	unknownContentSize prometheus.Counter
+}
+
+func New(T http.RoundTripper) *BandwidthObserver {
+	if T == nil {
+		T = http.DefaultTransport
+	}
+	return &BandwidthObserver{
+		T: T,
+		bytesUploaded: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "speedtest_bytes_uploaded",
+			Help: "Total bytes uploaded",
+		}),
+		bytesDownloaded: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "speedtest_bytes_downloaded",
+			Help: "Total bytes downloaded",
+		}),
+		unknownContentSize: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "speedtest_unknown_content_size",
+			Help: "Total number of times the content size was unknown",
+		}),
+	}
+}
+
+func (b *BandwidthObserver) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := b.T.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if req.ContentLength > 0 {
+		if req.Body == nil {
+			log.Debug().Msg("Ghosts in the Machine!")
+		}
+		b.bytesUploaded.Add(float64(req.ContentLength))
+	} else if req.Body != nil {
+		log.Debug().
+			Int64("content-length", req.ContentLength).
+			Str("method", req.Method).
+			Str("url", req.URL.String()).
+			Msg("unknown request content size")
+		b.unknownContentSize.Inc()
+	}
+	if resp.ContentLength > 0 {
+		b.bytesDownloaded.Add(float64(resp.ContentLength))
+	} else {
+		b.unknownContentSize.Inc()
+		log.Debug().
+			Int64("content-length", req.ContentLength).
+			Str("method", req.Method).
+			Str("url", req.URL.String()).
+			Msg("unknown response content size")
+	}
+	return resp, err
+}
+
+func (b *BandwidthObserver) Describe(ch chan<- *prometheus.Desc) {
+	ch <- b.bytesUploaded.Desc()
+	ch <- b.bytesDownloaded.Desc()
+	ch <- b.unknownContentSize.Desc()
+}
+
+func (b *BandwidthObserver) Collect(ch chan<- prometheus.Metric) {
+	ch <- b.bytesUploaded
+	ch <- b.bytesDownloaded
+	ch <- b.unknownContentSize
+}

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -47,6 +47,7 @@ func TestCollect(t *testing.T) {
 		Doer: NewTestClient(),
 		Ctx:  ctx,
 	})
+	e.UpdateResults()
 	ch := make(chan prometheus.Metric)
 	received := 0
 	go func() {
@@ -97,6 +98,7 @@ func TestAllMetricsPopulated(t *testing.T) {
 		Doer: NewTestClient(),
 		Ctx:  ctx,
 	})
+	e.UpdateResults()
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(e)
 

--- a/kubernetes/manifests/servicemonitor.yaml
+++ b/kubernetes/manifests/servicemonitor.yaml
@@ -15,7 +15,6 @@ spec:
   endpoints:
     - port: http-metrics
       scheme: http
-      interval: 30m
   jobLabel: jobLabel
   selector:
     matchLabels:


### PR DESCRIPTION
This is actually a somewhat substantial PR, which does two things:
1. Updates the exporter to run speed tests asyncronously in a goroutine
2. Creates a bandwidth observer to collect & report bandwidth usage statistics.

Signed-off-by: Russell Troxel <russell.troxel@segment.com>